### PR TITLE
Initialize JEKYLL_BUILD_REVISION with GITHUB_SHA

### DIFF
--- a/action.yml.erb
+++ b/action.yml.erb
@@ -15,6 +15,10 @@ inputs:
     description: 'Publishes posts with a future date.'
     required: false
     default: true
+  build_revision:
+    description: 'The SHA-1 of the git commit for which the build is running. Default to GITHUB_SHA when not provided.'
+    required: false
+    default:
   verbose:
     description: 'Verbose output'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@ GITHUB_PAGES=$PAGES_GEM_HOME/bin/github-pages
 export JEKYLL_ENV="production"
 export JEKYLL_GITHUB_TOKEN=$INPUT_TOKEN
 export PAGES_REPO_NWO=$GITHUB_REPOSITORY
+export JEKYLL_BUILD_REVISION=${INPUT_BUILD_REVISION:="$GITHUB_SHA"}
 
 # Set verbose flag
 if [ "$INPUT_VERBOSE" = 'true' ]; then


### PR DESCRIPTION
Initialize the `JEKYLL_BUILD_REVISION` environment variable with `GITHUB_SHA` by default.

This will allow https://github.com/jekyll/github-metadata/ to report the commit a Pages site was build from again. This became an empty string with the move to Pages on Actions.

Add an optional input to customize that in the medium term too.