### PR TITLE
Revert to not setting the future option

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default PR reviewers
+* @actions/pages

--- a/action.yml.erb
+++ b/action.yml.erb
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ./_site
   future:
-    description: 'Publishes posts with a future date.'
+    description: 'Publishes posts with a future date. When set to true, the build is made with the --future option which overrides the future option that may be set in a Jekyll configuration file.'
     required: false
     default: false
   build_revision:

--- a/action.yml.erb
+++ b/action.yml.erb
@@ -14,7 +14,7 @@ inputs:
   future:
     description: 'Publishes posts with a future date.'
     required: false
-    default: true
+    default: false
   build_revision:
     description: 'The SHA-1 of the git commit for which the build is running. Default to GITHUB_SHA.'
     required: false


### PR DESCRIPTION
This PR addresses https://github.com/actions/jekyll-build-pages/issues/9.

Pages builds will now respect Jekyll's default and have the `future` option set to `false`. See  [documentation](https://jekyllrb.com/docs/upgrading/2-to-3/#future-posts).

Note that this is a small breaking change from the old way of building Pages sites (not using Actions) where we used to have `future` defaulting to `true`. This was implemented with logic parsing and overriding users' Jekyll configuration files.

We are making this change to support a more transparent Jekyll integration, now and in the future.

The option can both be enabled/disabled at the discretion of a Pages site owner in [their Jekyll configuration file](https://jekyllrb.com/tutorials/convert-site-to-jekyll/#4-add-a-configuration-file).