### PR TITLE
Emit telemetry after building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 COPY entrypoint.sh /entrypoint.sh
+COPY bin/emit_telemetry /emit_telemetry
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gem "github-pages", "= 225"
 # even though it is included in the original GitHub Pages build infrastructure.
 gem "jekyll-include-cache", "= 0.2.1"
 gem "jekyll-octicons", "~> 14.2"
+gem "faraday", "~> 1.10"

--- a/bin/emit_telemetry
+++ b/bin/emit_telemetry
@@ -1,0 +1,41 @@
+#! /usr/bin/env ruby
+
+require "faraday"
+require "faraday/retry"
+require "json"
+
+ACTION_NWO = ENV["GITHUB_ACTION_REPOSITORY"]
+REPOSITORY_NWO = ENV["GITHUB_REPOSITORY"]
+GITHUB_RUN_ID = ENV["GITHUB_RUN_ID"]
+GITHUB_TOKEN = ENV["INPUT_TOKEN"]
+TELEMETRY_URL = "https://api.github.com/repos/#{REPOSITORY_NWO}/pages/telemetry"
+RETRY_COUNT = 3
+
+RETRY_OPTIONS = {
+  max: RETRY_COUNT,
+  methods: [:post],
+  retry_statuses: [500, 502, 503, 504],
+  interval: 1,
+  backoff_factor: 2,
+}
+
+begin
+  connection = Faraday.new { |f| f.request :retry, RETRY_OPTIONS }
+  response = connection.post(
+    TELEMETRY_URL,
+    { github_run_id: GITHUB_RUN_ID }.to_json,
+    {
+      Accept: 'application/vnd.github.v3+json',
+      Authorization: "Bearer #{GITHUB_TOKEN}",
+      'Content-type': 'application/json',
+      'User-Agent': "#{ACTION_NWO} Faraday #{Faraday::VERSION}",
+    },
+  )
+
+  unless response.success?
+    STDERR.puts "failed to emit pages build telemetry to #{TELEMETRY_URL}: returned status code: #{response.status} after #{RETRY_COUNT + 1} attempts"
+    STDERR.puts response.body if response.body
+  end
+rescue e
+  STDERR.puts "failed to emit pages build telemetry: #{e}"
+end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,3 +35,5 @@ fi
 
 cd "$PAGES_GEM_HOME"
 $GITHUB_PAGES build "$VERBOSE" "$FUTURE" --source "$SOURCE_DIRECTORY" --destination "$DESTINATION_DIRECTORY"
+
+/emit_telemetry


### PR DESCRIPTION
This commit duplicates the [telemetry logic in the actions/deploy-pages action](https://github.com/paper-spa/deploy-pages/blob/59b61e6d9c4d58f62adcdeedf5a440529ff69b23/src/pre.js).
This Gemfile already pulls in Faraday as a dependency of octokit; the change to
Gemfile just makes its use explicit. There aren't any changes when you compare
the resulting Gemfile.lock.