### PR TITLE
Upgrade to checkout@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Grep action.yaml content
         id: grep-image-content
         run: |


### PR DESCRIPTION
Node.js 12 actions are deprecated as of 27/9/2022. Only Node.js 16 is currently supported for actions. This has caused issues with "Build with Jelkyll" job.

source: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/