### PR TITLE
Deprecate set-output

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,7 +43,7 @@ jobs:
           else
             tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           fi
-          echo "::set-output name=tags::$tags"
+          echo "tags=$tags" >> $GITHUB_OUTPUT
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v3

--- a/.github/workflows/record.yml
+++ b/.github/workflows/record.yml
@@ -21,7 +21,7 @@ jobs:
         id: grep-image-content
         run: |
           image=$(grep -E "jekyll-build-pages.*\'" action.yml)
-          echo "::set-output name=image::$image"
+          echo "image=$image" >> $GITHUB_OUTPUT
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex-match
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         id: grep-image-content
         run: |
           image=$(grep -E "jekyll-build-pages.*\'" action.yml)
-          echo "::set-output name=image::$image"
+          echo "image=$image" >> $GITHUB_OUTPUT
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex-match
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         id: grep-image-content
         run: |
           image=$(grep -E "jekyll-build-pages.*\'" action.yml)
-          echo "::set-output name=image::$image"
+          echo "image=$image" >> $GITHUB_OUTPUT
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex-match
         with:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://github.com/github/pages-engineering/issues/2038