### PR TITLE
Emergency: drop ghcr dependency temporarily

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,4 +28,4 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/actions/jekyll-build-pages:v1.0.6'
+  image: 'Dockerfile'


### PR DESCRIPTION
With GitHub Packages down, considering building the container at runtime instead (temporarily).

Validation: https://github.com/yoannchaudet/page1/actions/runs/3549089993/jobs/5961053361