### PR TITLE
Print a warning if Gemfile's dependencies are not satisfied

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,11 @@ DESTINATION_DIRECTORY=${GITHUB_WORKSPACE}/$INPUT_DESTINATION
 PAGES_GEM_HOME=$BUNDLE_APP_CONFIG
 GITHUB_PAGES=$PAGES_GEM_HOME/bin/github-pages
 
+# Check if Gemfile's dependencies are satisfied or print a warning 
+if test -e "$SOURCE_DIRECTORY/Gemfile" && ! bundle check --dry-run --gemfile "$SOURCE_DIRECTORY/Gemfile" >/dev/null 2>&1; then
+  echo "::warning:: github-pages can't satisfy your Gemfile's dependencies."
+fi
+
 # Set environment variables required by supported plugins
 export JEKYLL_ENV="production"
 export JEKYLL_GITHUB_TOKEN=$INPUT_TOKEN


### PR DESCRIPTION
I observed is that lots of people install Jekyll 4.x locally with their own choices of dependency, test with that locally and check in the Gemfile. Then on GitHub it builds the site using Jekyll 3.x with a different set of dependency. The end results of this is very YMMV. It works sometimes, but in most cases won't. - E.g. #46

To some degree it is a user problem that they are using "jekyll" gem locally and the action runs "github-pages" gem, but this action is named "jekyll-build-pages" so that I think most of the users will get confused by what it actually does.

This PR prints a warning if we detect a Gemfile and found that some dependencies in the Gemfile cannot be met via "github-pages" gem preinstalled in the container, giving user some hints about what might be causing their build failure. 