### PR TITLE
Fix shell issues + adjust linter

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - '**.sh'
+      # this is too wide but will cover shell scripts without an extension in that folder
+      - 'bin/*'
 
 jobs:
   shellcheck:

--- a/bin/record_expected_output
+++ b/bin/record_expected_output
@@ -5,9 +5,9 @@ if [ "local" = "$1" ]; then
   export PAGES_REPO_NWO=actions/jekyll-build-pages
   export JEKYLL_BUILD_REVISION=JEKYLL_BUILD_REVISION
 
-  for dir in $(ls test_projects)
+  for dir in test_projects/*
   do
-    bundle exec github-pages build --verbose -s test_projects/$dir -d test_projects/$dir/_expected
+    bundle exec github-pages build --verbose -s "test_projects/${dir}" -d "test_projects/${dir}/_expected"
   done
 else
   act -b -s GITHUB_TOKEN -j record-expected-output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-#######################################################################################################
+####################################################################################################
 #
-# Calls github-pages executable to build the site using whitelisted plugins and supported configuration
+# Calls github-pages executable to build the site using allowed plugins and supported configuration
 #
-#######################################################################################################
+####################################################################################################
 
 set -o errexit
 


### PR DESCRIPTION
Re-configure the linter to track files in `bin`. We have a shell script here without an extension so we cannot filter on it with an Actions workflow (🙃).

Also fix linter error while at it.

Should clear CI for https://github.com/actions/jekyll-build-pages/pull/61.