### PR TITLE
Add Dependabot config for Bundler and Actions usage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Formalize the default configuration -- though I'm uncertain if `Gemfile` alone is enough to normally cause Dependabot updates for Ruby? 🤔

Also add updates for Actions usage.