### PR TITLE
[Failed] Attempt at nesting composite actions to handle Docker registry fallback

### DIFF
--- a/composite-docker-ghcr/action.yml
+++ b/composite-docker-ghcr/action.yml
@@ -31,7 +31,8 @@ runs:
   steps:
     - name: Run Pages Jekyll build using GHCR Docker image
       #uses: paper-spa/jekyll-build-pages/docker-ghcr@v1.0.7
-      uses: actions/jekyll-build-pages@main
+      #uses: actions/jekyll-build-pages@main
+      uses: actions/jekyll-build-pages@v1.0.7
       with:
         source: ${{ inputs.source }}
         destination: ${{ inputs.destination }}

--- a/composite-docker-ghcr/action.yml
+++ b/composite-docker-ghcr/action.yml
@@ -1,4 +1,4 @@
-name: 'Build Jekyll for GitHub Pages'
+name: 'Build Jekyll for GitHub Pages (GHCR Docker Composite)'
 description: 'A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages'
 author: 'GitHub'
 inputs:
@@ -27,5 +27,15 @@ inputs:
     required: true
     default: ${{ github.token }}
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: composite
+  steps:
+    - name: Run Pages Jekyll build using GHCR Docker image
+      #uses: paper-spa/jekyll-build-pages/docker-ghcr@v1.0.7
+      uses: actions/jekyll-build-pages@main
+      with:
+        source: ${{ inputs.source }}
+        destination: ${{ inputs.destination }}
+        future: ${{ inputs.future }}
+        build_revision: ${{ inputs.build_revision }}
+        verbose: ${{ inputs.verbose }}
+        token: ${{ inputs.token }}

--- a/composite-docker-local/action.yml
+++ b/composite-docker-local/action.yml
@@ -1,4 +1,4 @@
-name: 'Build Jekyll for GitHub Pages'
+name: 'Build Jekyll for GitHub Pages (Local Docker Composite)'
 description: 'A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages'
 author: 'GitHub'
 inputs:
@@ -27,5 +27,15 @@ inputs:
     required: true
     default: ${{ github.token }}
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: composite
+  steps:
+    - name: Run Pages Jekyll build using local Docker image
+      #uses: paper-spa/jekyll-build-pages/docker-local@v1.0.7
+      uses: paper-spa/jekyll-build-pages@main
+      with:
+        source: ${{ inputs.source }}
+        destination: ${{ inputs.destination }}
+        future: ${{ inputs.future }}
+        build_revision: ${{ inputs.build_revision }}
+        verbose: ${{ inputs.verbose }}
+        token: ${{ inputs.token }}

--- a/composite-main/action.yml
+++ b/composite-main/action.yml
@@ -34,8 +34,12 @@ runs:
       # using an internal endpoint would be better than status page
       # but this is an acceptable starting point
       run: |
-        packagesStatus=$(curl -LSs https://www.githubstatus.com/api/v2/components.json | jq -r '.components[] | select(.name == "Packages") | .status')
-        echo status=$packagesStatus >> $GITHUB_OUTPUT
+        if [ -z "$FAKE_STATUS" ]; then
+          packagesStatus=$(curl -LSs https://www.githubstatus.com/api/v2/components.json | jq -r '.components[] | select(.name == "Packages") | .status')
+          echo status=$packagesStatus >> $GITHUB_OUTPUT
+        else
+          echo status=$FAKE_STATUS >> $GITHUB_OUTPUT
+        fi
 
     - if: ${{ steps.ghcr.outputs.status == 'operational' }}
       # load another composite action that pulls `docker://ghcr.io/...`

--- a/composite-main/action.yml
+++ b/composite-main/action.yml
@@ -1,0 +1,62 @@
+name: 'Build Jekyll for GitHub Pages (Composite)'
+description: 'A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages'
+author: 'GitHub'
+inputs:
+  source:
+    description: 'Directory where the source files reside.'
+    required: false
+    default: ./
+  destination:
+    description: 'Output directory of the build. Although it can be nested inside the source, it cannot be the same as the source directory.'
+    required: false
+    default: ./_site
+  future:
+    description: 'Publishes posts with a future date. When set to true, the build is made with the --future option which overrides the future option that may be set in a Jekyll configuration file.'
+    required: false
+    default: false
+  build_revision:
+    description: 'The SHA-1 of the git commit for which the build is running. Default to GITHUB_SHA.'
+    required: false
+    default: ${{ github.sha }}
+  verbose:
+    description: 'Verbose output'
+    required: false
+    default: true
+  token:
+    description: 'GitHub token'
+    required: true
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - name: Check GHCR status
+      id: ghcr
+      # using an internal endpoint would be better than status page
+      # but this is an acceptable starting point
+      run: |
+        packagesStatus=$(curl -LSs https://www.githubstatus.com/api/v2/components.json | jq -r '.components[] | select(.name == "Packages") | .status')
+        echo status=$packagesStatus >> $GITHUB_OUTPUT
+
+    - if: ${{ steps.ghcr.outputs.status == 'operational' }}
+      # load another composite action that pulls `docker://ghcr.io/...`
+      #uses: paper-spa/jekyll-build-pages/composite-docker-ghcr@v1.0.7
+      uses: paper-spa/jekyll-build-pages/composite-docker-ghcr@main
+      with:
+        source: ${{ inputs.source }}
+        destination: ${{ inputs.destination }}
+        future: ${{ inputs.future }}
+        build_revision: ${{ inputs.build_revision }}
+        verbose: ${{ inputs.verbose }}
+        token: ${{ inputs.token }}
+
+    - if: ${{ steps.ghcr.outputs.status != 'operational' }}
+      # load another composite action that builds the Docker image locally
+      #uses: paper-spa/jekyll-build-pages/composite-docker-local@v1.0.7
+      uses: paper-spa/jekyll-build-pages/composite-docker-local@main
+      with:
+        source: ${{ inputs.source }}
+        destination: ${{ inputs.destination }}
+        future: ${{ inputs.future }}
+        build_revision: ${{ inputs.build_revision }}
+        verbose: ${{ inputs.verbose }}
+        token: ${{ inputs.token }}

--- a/composite-main/action.yml
+++ b/composite-main/action.yml
@@ -31,6 +31,7 @@ runs:
   steps:
     - name: Check GHCR status
       id: ghcr
+      shell: sh
       # using an internal endpoint would be better than status page
       # but this is an acceptable starting point
       run: |

--- a/docker-ghcr/action.yml
+++ b/docker-ghcr/action.yml
@@ -1,4 +1,4 @@
-name: 'Build Jekyll for GitHub Pages'
+name: 'Build Jekyll for GitHub Pages (GHCR Docker)'
 description: 'A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages'
 author: 'GitHub'
 inputs:
@@ -28,4 +28,4 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/actions/jekyll-build-pages:v1.0.7'

--- a/docker-local/action.yml
+++ b/docker-local/action.yml
@@ -1,4 +1,4 @@
-name: 'Build Jekyll for GitHub Pages'
+name: 'Build Jekyll for GitHub Pages (Local Docker)'
 description: 'A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages'
 author: 'GitHub'
 inputs:


### PR DESCRIPTION
🧪 **Result:** Didn't work as expected. It still pulled/built all of the Docker images ahead of time before evaluating the steps' `if:` conditions. 😢

![result logs](https://user-images.githubusercontent.com/417751/228879397-9ffcbe33-76ff-4f5e-a53a-9f83bde046c4.png)

Usage was:

```yaml
name: Deploy Jekyll Pages site

on:
  push:
    branches: [main]
  workflow_dispatch:

permissions:
  contents: read
  pages: write
  id-token: write

concurrency:
  group: 'pages'
  cancel-in-progress: false

jobs:
  build-and-deploy:
    runs-on: ubuntu-latest
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}
    steps:
      - name: Checkout
        uses: actions/checkout@v3
      - name: Setup Pages
        uses: actions/configure-pages@v3
      - name: Build with Jekyll
        uses: paper-spa/jekyll-build-pages/composite-main@main
        with:
          source: ./
          destination: ./_site
      - name: Upload artifact
        uses: actions/upload-pages-artifact@v1
      - name: Deploy to GitHub Pages
        id: deployment
        uses: actions/deploy-pages@v2
``` 