### PR TITLE
Add steps to major version release to update Docker major tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,24 @@ jobs:
     outputs:
       major_tag: ${{ steps.update-major-tag.outputs.major-tag }}
     steps:
-    - name: Update the ${{ env.TAG_NAME }} tag
-      id: update-major-tag
-      uses: actions/publish-action@v0.2.2
-      with:
-        source-tag: ${{ env.TAG_NAME }}
-        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Update the ${{ env.TAG_NAME }} major tag
+        id: update-major-tag
+        uses: actions/publish-action@v0.2.2
+        with:
+          source-tag: ${{ env.TAG_NAME }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+
+      # Login to the GHCR Docker registry
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Docker image tag
+        env:
+          NEW_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.update-major-tag.outputs.major-tag }}
+          SOURCE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}
+        run: |
+          docker buildx imagetools create --tag $NEW_TAG $SOURCE_TAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/publish-action@v0.2.2
         with:
           source-tag: ${{ env.TAG_NAME }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
       # Login to the GHCR Docker registry
       - name: Log into registry ${{ env.REGISTRY }}


### PR DESCRIPTION
Closes #84

We have previously observed that our Docker major version tag has gotten outdated because Actions workflows cannot be triggered by a commit/tag created using the Actions-provided `GITHUB_TOKEN`.

These new steps on the end of the release process for updating the git major tag should also allow us to create/update the corresponding Docker major tag by references the latest full version tag. 🐳 

**Advantages:**
- This creates a new remote `v1` major image by just referencing the existing `v1.x.x` image instead of building it again as in #84, thus consuming less time and fewer resources
- Keeps the potential failure to create/update the corresponding Docker tag _with_ the same workflow run that creates/updates the git major tag, which provides better traceability 🔍 

**Disadvantages:**
- More workflow steps to manage and understand