### PR TITLE
Use PAT to allow natural workflow chaining for Docker tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,10 @@ jobs:
     outputs:
       major_tag: ${{ steps.update-major-tag.outputs.major-tag }}
     steps:
-    - name: Update the ${{ env.TAG_NAME }} tag
-      id: update-major-tag
-      uses: actions/publish-action@v0.2.2
-      with:
-        source-tag: ${{ env.TAG_NAME }}
-        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Update the ${{ env.TAG_NAME }} major tag
+        id: update-major-tag
+        uses: actions/publish-action@v0.2.2
+        with:
+          source-tag: ${{ env.TAG_NAME }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          token: ${{ secrets.PAGES_AUTOMATION_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,5 +56,4 @@ jobs:
         uses: actions/publish-action@v0.2.2
         with:
           source-tag: ${{ env.TAG_NAME }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
           token: ${{ secrets.PAGES_AUTOMATION_PAT }}


### PR DESCRIPTION
Closes #83 

We have previously observed that our Docker major version tag has gotten outdated because Actions workflows cannot be triggered by a commit/tag created using the Actions-provided `GITHUB_TOKEN`.

This modification to the end of the release process for updating the git major tag will now also use a PAT (instead of `GITHUB_TOKEN`) should allow natural workflow chaining so the related `docker-publish` workflow can run to create the Docker major tag. 🐳 

**Advantages:**
- No additional workflow steps to manage and understand

**Disadvantages:**
- We need to manage an org-level PAT (but we already were 🤷🏻)
- The `docker-publish` workflow will end up needing to build a new `v1` major image instead of just referencing the existing `v1.x.x` image as in #83, thus consuming more time and resources