### PR TITLE
Update local environment variable name to avoid conflict with `GITHUB_PAGES`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ set -o errexit
 SOURCE_DIRECTORY=${GITHUB_WORKSPACE}/$INPUT_SOURCE
 DESTINATION_DIRECTORY=${GITHUB_WORKSPACE}/$INPUT_DESTINATION
 PAGES_GEM_HOME=$BUNDLE_APP_CONFIG
-GITHUB_PAGES=$PAGES_GEM_HOME/bin/github-pages
+GITHUB_PAGES_BIN=$PAGES_GEM_HOME/bin/github-pages
 
 # Check if Gemfile's dependencies are satisfied or print a warning 
 if test -e "$SOURCE_DIRECTORY/Gemfile" && ! bundle check --dry-run --gemfile "$SOURCE_DIRECTORY/Gemfile" >/dev/null 2>&1; then
@@ -39,4 +39,4 @@ else
 fi
 
 cd "$PAGES_GEM_HOME"
-$GITHUB_PAGES build "$VERBOSE" "$FUTURE" --source "$SOURCE_DIRECTORY" --destination "$DESTINATION_DIRECTORY"
+$GITHUB_PAGES_BIN build "$VERBOSE" "$FUTURE" --source "$SOURCE_DIRECTORY" --destination "$DESTINATION_DIRECTORY"


### PR DESCRIPTION
A small extract from closed PR:
- #82 

We've more recently added an exported environment variable `GITHUB_PAGES=true` for our [`actions/deploy-pages`](https://github.com/actions/deploy-pages) action, so I thought it would be best to avoid confusion here.