### PR TITLE
Show the `bundle check` output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ PAGES_GEM_HOME=$BUNDLE_APP_CONFIG
 GITHUB_PAGES_BIN=$PAGES_GEM_HOME/bin/github-pages
 
 # Check if Gemfile's dependencies are satisfied or print a warning 
-if test -e "$SOURCE_DIRECTORY/Gemfile" && ! bundle check --dry-run --gemfile "$SOURCE_DIRECTORY/Gemfile" >/dev/null 2>&1; then
+if test -e "$SOURCE_DIRECTORY/Gemfile" && ! bundle check --dry-run --gemfile "$SOURCE_DIRECTORY/Gemfile"; then
   echo "::warning:: github-pages can't satisfy your Gemfile's dependencies."
 fi
 


### PR DESCRIPTION
Fixes https://github.com/actions/jekyll-build-pages/issues/79

Towards:
- https://github.com/actions/jekyll-build-pages/issues/79

Avoids the confusion if the [warning message](https://github.com/actions/jekyll-build-pages/blob/b5e22bcae764d5a8aa4f687ffc4032c6c75d7496/entrypoint.sh#L18) begins showing up:

```
Warning:  github-pages can't satisfy your Gemfile's dependencies.
```

I debated storing the output into a temporary file until we assess if the check failed but, for most cases, I think the output will be so small that it's not really worth the extra gymnastics. 🤷🏻 