### PR TITLE
Remove steps to publish Docker major tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,18 +56,3 @@ jobs:
         uses: actions/publish-action@v0.2.2
         with:
           source-tag: ${{ env.TAG_NAME }}
-
-      # Login to the GHCR Docker registry
-      - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update Docker image tag
-        env:
-          NEW_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.update-major-tag.outputs.major-tag }}
-          SOURCE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}
-        run: |
-          docker buildx imagetools create --tag $NEW_TAG $SOURCE_TAG


### PR DESCRIPTION
Reverts #83 

It doesn't work if the remote tag already exists and there isn't any option for overwriting. 🤦🏻 

Frankly, maintaining a major version tag of the underlying Docker container is not important for this action, given that the action's manifest (`action.yml`) references a specific version number (e.g. `v1.0.8`) anyway. 🤷🏻‍♂️ 

I've also gone ahead and pruned a few old/low-use tagged container versions (including `v1`) to reduce confusion. 🔪 