### PR TITLE
Update Dependabot config to group non-breaking changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      non-breaking-changes:
+        update-types: [minor, patch]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      non-breaking-changes:
+        update-types: [minor, patch]


### PR DESCRIPTION
Update the Dependabot configuration file such that all non-breaking changes for a given ecosystem will be combined into a single Dependabot PR. 1️⃣ 